### PR TITLE
Added parameters to set a .rviz configuration for the rqt_rviz plugin and disable the menu bar.

### DIFF
--- a/rqt_rviz/CMakeLists.txt
+++ b/rqt_rviz/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rqt_rviz)
 # Load catkin and all dependencies required for this package
+
+find_package(Boost REQUIRED COMPONENTS program_options)
+
 find_package(catkin REQUIRED COMPONENTS rqt_gui rqt_gui_cpp rviz)
 catkin_package(	
 	INCLUDE_DIRS ${rqt_rviz_INCLUDE_DIRECTORIES}

--- a/rqt_rviz/include/rqt_rviz/rviz.h
+++ b/rqt_rviz/include/rqt_rviz/rviz.h
@@ -58,6 +58,7 @@ public:
   virtual bool eventFilter(QObject* watched, QEvent* event);
 
 protected:
+  void parseArguments();
 
   qt_gui_cpp::PluginContext* context_;
 
@@ -65,6 +66,8 @@ protected:
 
   Ogre::Log* log_;
 
+  bool hide_menu_;
+  std::string display_config_;
 };
 
 }

--- a/rqt_rviz/scripts/rqt_rviz
+++ b/rqt_rviz/scripts/rqt_rviz
@@ -4,5 +4,16 @@ import sys
 
 from rqt_gui.main import Main
 
+import argparse
+
+def add_arguments(parser):
+    group = parser.add_argument_group('Options for rqt_rviz plugin')
+    group.add_argument('--hide-menu', '-x',
+            help='Hide RViz menu bar in plugin', 
+            action="store_true")
+    group.add_argument('--display-config', '-d', metavar='FILE',
+            type=argparse.FileType('r'),
+            help='A display config file (.rviz) to load')
+
 main = Main()
-sys.exit(main.main(sys.argv, standalone='rqt_rviz'))
+sys.exit(main.main(sys.argv, standalone='rqt_rviz', plugin_argument_provider=add_arguments))

--- a/rqt_rviz/src/rqt_rviz/rviz.cpp
+++ b/rqt_rviz/src/rqt_rviz/rviz.cpp
@@ -36,9 +36,9 @@
 #include <QMenuBar>
 
 #include <pluginlib/class_list_macros.h>
+#include <boost/program_options.hpp>
 
 #include <rqt_rviz/rviz.h>
-
 
 namespace rqt_rviz {
 
@@ -47,6 +47,7 @@ RViz::RViz()
   , context_(0)
   , widget_(0)
   , log_(0)
+  , hide_menu_(false)
 {
   setObjectName("RViz");
 }
@@ -64,6 +65,8 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
 {
   context_ = &context;
 
+  parseArguments();
+
   // prevent output of Ogre stuff to console
   Ogre::LogManager* log_manager = Ogre::LogManager::getSingletonPtr();
   if (!log_manager)
@@ -78,9 +81,10 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
   // create own menu bar to disable native menu bars on Unity and Mac
   QMenuBar* menu_bar = new QMenuBar();
   menu_bar->setNativeMenuBar(false);
+  menu_bar->setVisible(!hide_menu_);
   widget_->setMenuBar(menu_bar);
 
-  widget_->initialize();
+  widget_->initialize(display_config_.c_str());
 
   // disable quit action in menu bar
   QMenu* menu = 0;
@@ -115,6 +119,48 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
 
   // trigger deleteLater for plugin when widget or frame is closed
   widget_->installEventFilter(this);
+}
+
+void RViz::parseArguments()
+{
+  namespace po = boost::program_options;
+
+  const QStringList &qargv = context_->argv();
+
+  const int argc = qargv.count();
+  QByteArray argv_array[argc]; // storage for char arrays of args
+  const char *argv[argc+1];
+  argv[0] = ""; // dummy program name
+
+  for (int i = 0; i < argc; ++i)
+  {
+	  argv_array[i] = qargv.at(i).toLocal8Bit();
+	  argv[i+1] = argv_array[i].constData();
+  }
+
+  po::variables_map vm;
+  po::options_description options;
+  options.add_options()
+    ("display-config,d", po::value<std::string>(), "")
+    ("hide-menu,x", "");
+
+  try {
+    po::store(po::parse_command_line(argc+1, argv, options), vm);
+    po::notify(vm);
+
+	if (vm.count("hide-menu"))
+	{
+		hide_menu_ = true;
+	}
+
+	if (vm.count("display-config"))
+	{
+		display_config_ = vm["display-config"].as<std::string>();
+	}
+  }
+  catch (std::exception& e) {
+	  ROS_ERROR("Error parsing command line: %s", e.what());
+  }
 }
 
 bool RViz::eventFilter(QObject* watched, QEvent* event)


### PR DESCRIPTION
This addresses the question I posed on ROS answers:
http://answers.ros.org/question/98126/using-rqt_rviz-with-custom-rviz-config/

The parameters are local to the namespace rqt_rviz is run in, but not private. If I create a ros::NodeHandle object, the node name seems to come from rqt (like /rqt_gui_cpp_node_24524) and not the launch file so setting a private parameter from the launch file does not seem possible.
