### PR TITLE
Added menu hiding and config as command-line args - with fixes from #61.

### DIFF
--- a/rqt_rviz/CMakeLists.txt
+++ b/rqt_rviz/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rqt_rviz)
 # Load catkin and all dependencies required for this package
+
+find_package(Boost REQUIRED COMPONENTS program_options)
+include_directories(${Boost_INCLUDE_DIRS})
+
 find_package(catkin REQUIRED COMPONENTS rqt_gui rqt_gui_cpp rviz)
 catkin_package(	
 	INCLUDE_DIRS ${rqt_rviz_INCLUDE_DIRECTORIES}

--- a/rqt_rviz/include/rqt_rviz/rviz.h
+++ b/rqt_rviz/include/rqt_rviz/rviz.h
@@ -58,6 +58,7 @@ public:
   virtual bool eventFilter(QObject* watched, QEvent* event);
 
 protected:
+  void parseArguments();
 
   qt_gui_cpp::PluginContext* context_;
 
@@ -65,6 +66,8 @@ protected:
 
   Ogre::Log* log_;
 
+  bool hide_menu_;
+  std::string display_config_;
 };
 
 }

--- a/rqt_rviz/package.xml
+++ b/rqt_rviz/package.xml
@@ -17,10 +17,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>boost</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
   <build_depend>rviz</build_depend>
+  <run_depend>boost</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>rqt_gui_cpp</run_depend>

--- a/rqt_rviz/scripts/rqt_rviz
+++ b/rqt_rviz/scripts/rqt_rviz
@@ -4,5 +4,16 @@ import sys
 
 from rqt_gui.main import Main
 
+import argparse
+
+def add_arguments(parser):
+    group = parser.add_argument_group('Options for rqt_rviz plugin')
+    group.add_argument('--hide-menu', '-m',
+            help='Hide RViz menu bar in plugin',
+            action='store_true')
+    group.add_argument('--display-config', '-d', metavar='FILE',
+            type=argparse.FileType('r'),
+            help='A display config file (.rviz) to load')
+
 main = Main()
-sys.exit(main.main(sys.argv, standalone='rqt_rviz'))
+sys.exit(main.main(sys.argv, standalone='rqt_rviz', plugin_argument_provider=add_arguments))


### PR DESCRIPTION
A bit messy because the toplevel script needs to tell RQT about which
arguments belong to the plugins - so the arguments are specified twice,
once in the script and once in the CPP code where they are actually
used.

Includes fixes from #61.
