### PR TITLE
Load/save RViz plugin settings to perspective.

### DIFF
--- a/rqt_rviz/src/rqt_rviz/rviz.cpp
+++ b/rqt_rviz/src/rqt_rviz/rviz.cpp
@@ -129,13 +129,14 @@ void RViz::parseArguments()
   const QStringList& qargv = context_->argv();
 
   const int argc = qargv.count();
+  QByteArray argv_array[argc]; // storage for char arrays of args
   const char *argv[argc+1];
   argv[0] = ""; // dummy program name
 
   for (int i = 0; i < argc; ++i)
   {
-    QByteArray arg = qargv.at(i).toLocal8Bit();
-    argv[i+1] = arg.constData();
+    argv_array[i] = qargv.at(i).toLocal8Bit();
+    argv[i+1] = argv_array[i].constData();
   }
 
   po::variables_map vm;


### PR DESCRIPTION
Allows RViz plugin to be used without a menu and with a custom .rviz
file when used together with other rqt plugins.

A few caveats to this functionality:
- The perspective use-case is considered orthogonal to the command-line
  use case, so settings in the perspective file will override what is
  passed in on the command line - even though this is backwards. In the
  case of a multi-plugins rqt perspective, this doesn't matter since
  command line parameters won't be passed to rqt_rviz.
- It's expected that the perspective file will be edited by hand to
  achieve the correct configuration of the RViz plugin. Otherwise
  there's no good way to store these two settings in the perspective
  file without causing confusion for the user.
