### PR TITLE
making sure bag_plugin is installed

### DIFF
--- a/rqt_robot_monitor/CMakeLists.txt
+++ b/rqt_robot_monitor/CMakeLists.txt
@@ -5,7 +5,9 @@ find_package(catkin REQUIRED)
 catkin_package()
 catkin_python_setup()
 
-install(FILES plugin.xml
+install(FILES
+  bag_plugin.xml
+  plugin.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 


### PR DESCRIPTION
Looks like the bag plugin for rqt_robot_monitor in 0.4.0 was created but not installed so it wasn't working properly.
Testing was done on the source so we missed it.
