### PR TITLE
put topic diagnostic_agg into a global namespace

### DIFF
--- a/rqt_robot_dashboard/src/rqt_robot_dashboard/monitor_dash_widget.py
+++ b/rqt_robot_dashboard/src/rqt_robot_dashboard/monitor_dash_widget.py
@@ -119,7 +119,7 @@ class MonitorDashWidget(IconToolButton):
                     self._monitor_shown = False
                 else:
                     self._monitor = RobotMonitorWidget(self.context,
-                                                       'diagnostics_agg')
+                                                       '/diagnostics_agg')
                     if self._plugin_settings:
                         self._monitor.restore_settings(self._plugin_settings,
                                                        self._instance_settings)


### PR DESCRIPTION
which enables to launch any rqt_dashboard inside a namespace without effecting the diagnostic_agg topic. This should anyways be kept in a global namespace, no?