### PR TITLE
Especify RViz config file using a param

### DIFF
--- a/rqt_rviz/include/rqt_rviz/rviz.h
+++ b/rqt_rviz/include/rqt_rviz/rviz.h
@@ -33,6 +33,7 @@
 #ifndef rqt_rviz__RViz_H
 #define rqt_rviz__RViz_H
 
+#include <ros/ros.h>
 #include <rqt_gui_cpp/plugin.h>
 #include <rviz/visualization_frame.h>
 #include <OGRE/OgreLog.h>
@@ -60,6 +61,8 @@ public:
 protected:
   void parseArguments();
 
+  boost::shared_ptr<ros::NodeHandle> _nh;
+
   qt_gui_cpp::PluginContext* context_;
 
   rviz::VisualizationFrame* widget_;
@@ -68,6 +71,8 @@ protected:
 
   bool hide_menu_;
   std::string display_config_;
+
+  std::string name_file_;
 };
 
 }

--- a/rqt_rviz/src/rqt_rviz/rviz.cpp
+++ b/rqt_rviz/src/rqt_rviz/rviz.cpp
@@ -40,7 +40,6 @@
 
 #include <rqt_rviz/rviz.h>
 
-
 namespace rqt_rviz {
 
 RViz::RViz()
@@ -50,6 +49,8 @@ RViz::RViz()
   , log_(0)
   , hide_menu_(false)
 {
+  _nh = boost::shared_ptr<ros::NodeHandle>(new ros::NodeHandle(""));
+  _nh->getParam("rviz_file", name_file_);
   setObjectName("RViz");
 }
 
@@ -85,7 +86,7 @@ void RViz::initPlugin(qt_gui_cpp::PluginContext& context)
   menu_bar->setVisible(!hide_menu_);
   widget_->setMenuBar(menu_bar);
 
-  widget_->initialize(display_config_.c_str());
+  widget_->initialize(QString::fromStdString(name_file_));
 
   // disable quit action in menu bar
   QMenu* menu = 0;

--- a/rqt_rviz/src/rqt_rviz/rviz.cpp
+++ b/rqt_rviz/src/rqt_rviz/rviz.cpp
@@ -37,7 +37,6 @@
 
 #include <pluginlib/class_list_macros.h>
 #include <boost/program_options.hpp>
-
 #include <rqt_rviz/rviz.h>
 
 namespace rqt_rviz {


### PR DESCRIPTION
Minor modifications to allow to the user load a RViz configuration file as a param.
