### PR TITLE
additionally support Qt5

### DIFF
--- a/rqt_moveit/package.xml
+++ b/rqt_moveit/package.xml
@@ -28,6 +28,7 @@
   <url type="bugtracker">https://github.com/ros-visualization/rqt_robot_plugins/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>rosnode</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>rostopic</run_depend>

--- a/rqt_moveit/src/rqt_moveit/moveit_widget.py
+++ b/rqt_moveit/src/rqt_moveit/moveit_widget.py
@@ -39,7 +39,8 @@ import time
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import QModelIndex, QTimer, Signal
-from python_qt_binding.QtGui import QStandardItem, QStandardItemModel, QWidget
+from python_qt_binding.QtGui import QStandardItem, QStandardItemModel
+from python_qt_binding.QtWidgets import QWidget
 import rospkg
 #from rosnode import rosnode_ping, ROSNodeIOException
 #from rosnode import ROSNodeIOException

--- a/rqt_nav_view/package.xml
+++ b/rqt_nav_view/package.xml
@@ -16,7 +16,7 @@
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
-  <run_depend>python_qt_binding</run_depend>
+  <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>qt_gui</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>rqt_gui</run_depend>

--- a/rqt_nav_view/src/rqt_nav_view/nav_view.py
+++ b/rqt_nav_view/src/rqt_nav_view/nav_view.py
@@ -42,7 +42,8 @@ from nav_msgs.msg import OccupancyGrid, Path
 from geometry_msgs.msg import PolygonStamped, PointStamped, PoseWithCovarianceStamped, PoseStamped
 
 from python_qt_binding.QtCore import Signal, Slot, QPointF, qWarning, Qt
-from python_qt_binding.QtGui import QWidget, QPixmap, QImage, QGraphicsView, QGraphicsScene, QPainterPath, QPen, QPolygonF, QVBoxLayout, QHBoxLayout, QColor, qRgb, QPushButton
+from python_qt_binding.QtGui import QPixmap, QImage, QPainterPath, QPen, QPolygonF, QColor, qRgb
+from python_qt_binding.QtWidgets import QWidget, QGraphicsView, QGraphicsScene, QVBoxLayout, QHBoxLayout, QPushButton
 
 from rqt_py_common.topic_helpers import get_field_type
 

--- a/rqt_pose_view/package.xml
+++ b/rqt_pose_view/package.xml
@@ -17,7 +17,7 @@
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend>python-opengl</run_depend>
-  <run_depend>python_qt_binding</run_depend>
+  <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>python-qt-bindings-gl</run_depend>
   <run_depend>python-rospkg</run_depend>
   <run_depend>rospy</run_depend>

--- a/rqt_pose_view/src/rqt_pose_view/pose_view_widget.py
+++ b/rqt_pose_view/src/rqt_pose_view/pose_view_widget.py
@@ -34,7 +34,7 @@ import rospkg
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Qt, QTimer, qWarning, Slot
-from python_qt_binding.QtGui import QAction, QMenu, QWidget
+from python_qt_binding.QtWidgets import QAction, QMenu, QWidget
 
 import rospy
 from rostopic import get_topic_class

--- a/rqt_robot_dashboard/package.xml
+++ b/rqt_robot_dashboard/package.xml
@@ -15,7 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>python_qt_binding</run_depend>
+  <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>qt_gui</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend version_gte="0.3.1">rqt_console</run_depend>

--- a/rqt_robot_dashboard/src/rqt_robot_dashboard/battery_dash_widget.py
+++ b/rqt_robot_dashboard/src/rqt_robot_dashboard/battery_dash_widget.py
@@ -34,7 +34,7 @@
 import os
 import rospkg
 from python_qt_binding.QtCore import Signal, QSize
-from python_qt_binding.QtGui import QLabel
+from python_qt_binding.QtWidgets import QLabel
 from .util import IconHelper
 
 class BatteryDashWidget(QLabel):

--- a/rqt_robot_dashboard/src/rqt_robot_dashboard/dashboard.py
+++ b/rqt_robot_dashboard/src/rqt_robot_dashboard/dashboard.py
@@ -31,7 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from python_qt_binding.QtCore import QSize, Qt
-from python_qt_binding.QtGui import QToolBar, QGroupBox, QHBoxLayout
+from python_qt_binding.QtWidgets import QToolBar, QGroupBox, QHBoxLayout
 from qt_gui.plugin import Plugin
 
 

--- a/rqt_robot_dashboard/src/rqt_robot_dashboard/icon_tool_button.py
+++ b/rqt_robot_dashboard/src/rqt_robot_dashboard/icon_tool_button.py
@@ -33,7 +33,7 @@
 import os
 
 from python_qt_binding.QtCore import Signal
-from python_qt_binding.QtGui import QToolButton
+from python_qt_binding.QtWidgets import QToolButton
 import rospy
 
 from .util import IconHelper

--- a/rqt_robot_dashboard/src/rqt_robot_dashboard/util.py
+++ b/rqt_robot_dashboard/src/rqt_robot_dashboard/util.py
@@ -34,7 +34,8 @@ import os
 
 import rospy
 
-from python_qt_binding.QtGui import QIcon, QImage, QMessageBox, QPainter, QPixmap
+from python_qt_binding.QtGui import QIcon, QImage, QPainter, QPixmap
+from python_qt_binding.QtWidgets import QMessageBox
 from python_qt_binding.QtSvg import QSvgRenderer
 
 

--- a/rqt_robot_dashboard/test/test_battery_dash_widget.py
+++ b/rqt_robot_dashboard/test/test_battery_dash_widget.py
@@ -36,7 +36,7 @@
 
 import unittest
 
-from python_qt_binding.QtGui import QApplication
+from python_qt_binding.QtWidgets import QApplication
 
 from rqt_robot_dashboard.battery_dash_widget import BatteryDashWidget
 

--- a/rqt_robot_monitor/package.xml
+++ b/rqt_robot_monitor/package.xml
@@ -33,7 +33,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>python_qt_binding</run_depend>
+  <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>python-rospkg</run_depend>
   <run_depend>qt_gui</run_depend>
   <run_depend>qt_gui_py_common</run_depend>

--- a/rqt_robot_monitor/src/rqt_robot_monitor/inspector_window.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/inspector_window.py
@@ -33,7 +33,7 @@
 # Author: Isaac Saito, Ze'ev Klapow, Austin Hendrix
 
 from python_qt_binding.QtCore import Signal, Slot
-from python_qt_binding.QtGui import QPushButton, QTextEdit, QVBoxLayout, QWidget
+from python_qt_binding.QtWidgets import QPushButton, QTextEdit, QVBoxLayout, QWidget
 import rospy
 
 from .status_snapshot import StatusSnapshot, level_to_text

--- a/rqt_robot_monitor/src/rqt_robot_monitor/robot_monitor.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/robot_monitor.py
@@ -38,7 +38,8 @@ import rospkg
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import QTimer, Signal, Qt, Slot
-from python_qt_binding.QtGui import QPalette, QWidget
+from python_qt_binding.QtGui import QPalette
+from python_qt_binding.QtWidgets import QWidget
 import rospy
 
 from .inspector_window import InspectorWindow

--- a/rqt_robot_monitor/src/rqt_robot_monitor/status_item.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/status_item.py
@@ -32,7 +32,7 @@
 #
 # Author: Austin Hendrix
 
-from python_qt_binding.QtGui import QTreeWidgetItem
+from python_qt_binding.QtWidgets import QTreeWidgetItem
 import util_robot_monitor as util
 
 class _StatusItem(QTreeWidgetItem):

--- a/rqt_robot_monitor/src/rqt_robot_monitor/status_snapshot.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/status_snapshot.py
@@ -35,7 +35,7 @@
 # TODO(ahendrix):
 #   better formatting of key-value pairs in a table
 
-from python_qt_binding.QtGui import QTextEdit
+from python_qt_binding.QtWidgets import QTextEdit
 from python_qt_binding.QtCore import Signal
 
 from diagnostic_msgs.msg import DiagnosticStatus

--- a/rqt_robot_monitor/src/rqt_robot_monitor/timeline_pane.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/timeline_pane.py
@@ -36,7 +36,7 @@ import os
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Signal, Slot
-from python_qt_binding.QtGui import QWidget
+from python_qt_binding.QtWidgets import QWidget
 import rospy
 import rospkg
 

--- a/rqt_robot_monitor/src/rqt_robot_monitor/timeline_view.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/timeline_view.py
@@ -36,8 +36,9 @@ from math import floor
 import rospy
 
 from python_qt_binding.QtCore import QPointF, Signal, Slot
-from python_qt_binding.QtGui import (QColor, QGraphicsPixmapItem,
-                                     QGraphicsView, QIcon, QGraphicsScene)
+from python_qt_binding.QtGui import QColor, QIcon
+from python_qt_binding.QtWidgets import QGraphicsPixmapItem, QGraphicsView, \
+    QGraphicsScene
 
 import util_robot_monitor as util
 

--- a/rqt_robot_steering/package.xml
+++ b/rqt_robot_steering/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>geometry_msgs</run_depend>
+  <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>python-rospkg</run_depend>
   <run_depend>rostopic</run_depend>
   <run_depend>rqt_gui</run_depend>

--- a/rqt_robot_steering/src/rqt_robot_steering/robot_steering.py
+++ b/rqt_robot_steering/src/rqt_robot_steering/robot_steering.py
@@ -36,7 +36,8 @@ from geometry_msgs.msg import Twist
 import rospy
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Qt, QTimer, Slot
-from python_qt_binding.QtGui import QKeySequence, QShortcut, QWidget
+from python_qt_binding.QtGui import QKeySequence
+from python_qt_binding.QtWidgets import QShortcut, QWidget
 from rqt_gui_py.plugin import Plugin
 
 

--- a/rqt_runtime_monitor/package.xml
+++ b/rqt_runtime_monitor/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>diagnostic_msgs</run_depend>
+  <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>python-rospkg</run_depend>
   <run_depend>qt_gui</run_depend>
   <run_depend>rospy</run_depend>

--- a/rqt_runtime_monitor/src/rqt_runtime_monitor/runtime_monitor_widget.py
+++ b/rqt_runtime_monitor/src/rqt_runtime_monitor/runtime_monitor_widget.py
@@ -39,7 +39,8 @@ import threading
 
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
 from python_qt_binding import loadUi
-from python_qt_binding.QtGui import QIcon, QTreeWidgetItem, QWidget
+from python_qt_binding.QtGui import QIcon
+from python_qt_binding.QtWidgets import QTreeWidgetItem, QWidget
 from python_qt_binding.QtCore import Qt, QTimer, QObject
 import rospy
 

--- a/rqt_tf_tree/package.xml
+++ b/rqt_tf_tree/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>geometry_msgs</run_depend>
+  <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>python-rospkg</run_depend>
   <run_depend>qt_dotgraph</run_depend>
   <run_depend>rospy</run_depend>

--- a/rqt_tf_tree/src/rqt_tf_tree/tf_tree.py
+++ b/rqt_tf_tree/src/rqt_tf_tree/tf_tree.py
@@ -42,7 +42,8 @@ import tf2_ros
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import QFile, QIODevice, QObject, Qt, Signal
-from python_qt_binding.QtGui import QFileDialog, QGraphicsScene, QIcon, QImage, QPainter, QWidget
+from python_qt_binding.QtGui import QIcon, QImage, QPainter
+from python_qt_binding.QtWidgets import QFileDialog, QGraphicsScene, QWidget
 from python_qt_binding.QtSvg import QSvgGenerator
 from qt_dotgraph.pydotfactory import PydotFactory
 # from qt_dotgraph.pygraphvizfactory import PygraphvizFactory


### PR DESCRIPTION
With these patches the same code base can run with:

* ROS Indigo / Jade using Qt 4
* ROS Kinetic (and higher) using Qt 5

The version dependency on `python_qt_binding` ensures that the packages which use `QtWidgets` are getting the changes from ros-visualization/python_qt_binding#31.

This is required for a release into Kinetic.