### PR TITLE
rqt_rviz: Persisting rviz configuration in plugin (instance) settings.

### DIFF
--- a/rqt_rviz/include/rqt_rviz/rviz.h
+++ b/rqt_rviz/include/rqt_rviz/rviz.h
@@ -55,6 +55,10 @@ public:
 
   virtual void initPlugin(qt_gui_cpp::PluginContext& context);
 
+  virtual void saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::Settings& instance_settings) const;
+
+  virtual void restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings);
+
   virtual bool eventFilter(QObject* watched, QEvent* event);
 
 protected:

--- a/rqt_rviz/src/rqt_rviz/rviz.cpp
+++ b/rqt_rviz/src/rqt_rviz/rviz.cpp
@@ -39,6 +39,8 @@
 #include <boost/program_options.hpp>
 
 #include <rqt_rviz/rviz.h>
+#include <rviz/yaml_config_writer.h>
+#include <rviz/yaml_config_reader.h>
 
 
 namespace rqt_rviz {
@@ -187,6 +189,34 @@ bool RViz::eventFilter(QObject* watched, QEvent* event)
   }
 
   return QObject::eventFilter(watched, event);
+}
+
+void RViz::saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::Settings& instance_settings) const {
+  rviz::YamlConfigWriter writer;
+  rviz::Config conf;
+
+  widget_->save(conf);
+
+  instance_settings.setValue("config", writer.writeString(conf));
+
+  if(writer.error())
+  {
+    ROS_ERROR( "%s", qPrintable( writer.errorMessage() ));
+  }
+}
+
+void RViz::restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings) {
+  rviz::YamlConfigReader reader;
+  rviz::Config conf;
+
+  if(instance_settings.contains("config")) {
+    reader.readString(conf, instance_settings.value("config").toString());
+    widget_->load(conf);
+  }
+
+  if(reader.error()) {
+    ROS_ERROR( "%s", qPrintable( reader.errorMessage() ));
+  }
 }
 
 }


### PR DESCRIPTION
This aims to be a different implementation to solve the underlying problems (as far as I can tell) of #94 and #86, by saving the rviz configuration as a rqt setting.

We need this, since we have some rqt perspectives which are used as control interfaces for end users and we want to be able to automatically start these interfaces without needing to tell the user to load the rviz configuration.

For details, please have a look at the commit message.

There is one caveat, which is that it will overwrite the display config specified as a command line argument (unless one passes `--clear-config` as well). How do you feel about this? Should `-d/--display-config` overwrite the saved one? Could we drop the command line arguments? (I don't feel like they are useful, since the only way to pass them is by running `rosrun rqt_rviz rqt_rviz`, where one could easily do `rosrun rviz rviz` instead. Are there any benefits of invoking it as a standalone rqt_plugin?)
I think this would be very easy to fix, but I would like to hear your opinion first :)
