### PR TITLE
add missing dependency

### DIFF
--- a/rqt_tf_tree/package.xml
+++ b/rqt_tf_tree/package.xml
@@ -15,6 +15,7 @@
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
+  <run_depend>python-pydot</run_depend>
   <run_depend>python-rospkg</run_depend>
   <run_depend>qt_dotgraph</run_depend>
   <run_depend>rospy</run_depend>


### PR DESCRIPTION
```
PluginHandlerDirect._restore_settings() plugin "rqt_tf_tree/RosTfTree#1" raised an exception:
Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/plugin_handler_direct.py", line 116, in _restore_settings
    self._plugin.restore_settings(plugin_settings_plugin, instance_settings_plugin)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_tf_tree/tf_tree.py", line 128, in restore_settings
    self._refresh_tf_graph()
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_tf_tree/tf_tree.py", line 137, in _refresh_tf_graph
    self._update_graph_view(self._generate_dotcode())
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_tf_tree/tf_tree.py", line 152, in _update_graph_view
    self._redraw_graph_view()
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_tf_tree/tf_tree.py", line 166, in _redraw_graph_view
    highlight_level)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_dotgraph/dot_to_qt.py", line 248, in dotcode_to_qt_items
    graph = pydot.graph_from_dot_data(dotcode.encode("ascii", "ignore"))
  File "/usr/lib/python2.7/dist-packages/pydot.py", line 220, in graph_from_dot_data
    return dot_parser.parse_dot_data(data)
NameError: global name 'dot_parser' is not defined
```