### PR TITLE
Fixed division by zero, console spamming and threading issues

### DIFF
--- a/rqt_moveit/src/rqt_moveit/moveit_widget.py
+++ b/rqt_moveit/src/rqt_moveit/moveit_widget.py
@@ -37,7 +37,6 @@ import sys
 import threading
 import xmlrpclib
 
-from threading import Thread
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import QModelIndex, QTimer, Signal
 from python_qt_binding.QtGui import QStandardItem, QStandardItemModel
@@ -120,7 +119,7 @@ class MoveitWidget(QWidget):
         self._root_qitem = self._node_datamodel.invisibleRootItem()
         self._view_nodes.setModel(self._node_datamodel)
 
-        node_monitor_thread = Thread(target=self._check_nodes_alive,
+        node_monitor_thread = threading.Thread(target=self._check_nodes_alive,
                                      args=(self.sig_node, self._nodes_monitored, self._stop_event))
 
         self.sig_node.connect(self._update_output_nodes)
@@ -166,7 +165,7 @@ class MoveitWidget(QWidget):
         """
         @rtype: Thread
         """
-        topic_monitor_thread = Thread(target=self._check_topics_alive,
+        topic_monitor_thread = threading.Thread(target=self._check_topics_alive,
                                       args=(self.sig_topic, self._selected_topics, self._stop_event))
         self.sig_topic.connect(self._update_output_topics)
         return topic_monitor_thread
@@ -215,7 +214,7 @@ class MoveitWidget(QWidget):
 
         self.sig_param.connect(self._update_output_parameters)
 
-        param_check_thread = Thread(target=self._check_params_alive,
+        param_check_thread = threading.Thread(target=self._check_params_alive,
                                     args=(self.sig_param, self._params_monitored, self._stop_event))
         return param_check_thread
 

--- a/rqt_moveit/src/rqt_moveit/moveit_widget.py
+++ b/rqt_moveit/src/rqt_moveit/moveit_widget.py
@@ -143,11 +143,9 @@ class MoveitWidget(QWidget):
         rosnode_dynamically_loaded = __import__('rosnode')
         while True:
             for nodename in nodes_monitored:
-                is_node_running = False
                 try:
                     registered_nodes = rosnode_dynamically_loaded.get_node_names()
-                    if nodename in registered_nodes:
-                        is_node_running = True
+                    is_node_running = nodename in registered_nodes
 
                 except rosnode_dynamically_loaded.ROSNodeIOException as e:
                     # TODO: Needs to be indicated on GUI

--- a/rqt_moveit/src/rqt_moveit/moveit_widget.py
+++ b/rqt_moveit/src/rqt_moveit/moveit_widget.py
@@ -353,6 +353,11 @@ class MoveitWidget(QWidget):
         """
         try:
             self._stop_event.set()
+
+            self._node_monitor_thread.join()
+            self._param_check_thread.join()
+            self._topic_monitor_thread.join()
+
             self._node_monitor_thread = None
             self._param_check_thread = None
             self._topic_monitor_thread = None

--- a/rqt_moveit/src/rqt_moveit/moveit_widget.py
+++ b/rqt_moveit/src/rqt_moveit/moveit_widget.py
@@ -106,13 +106,6 @@ class MoveitWidget(QWidget):
         self._topic_monitor_thread = self._init_monitor_topics()
         self._topic_monitor_thread.start()
 
-        # Delegate GUI functionality to rqt_topic.TopicWidget.
-        # To connect signal in a widget to PluginContainerWidget.
-        # TODO: In this way, Signal from only one instance is hooked.
-        # Not a good design at all.
-        # FIXME connect sys msg for nodes.
-        # self.sig_sysmsg = self._widget_topic.sig_sysmsg
-
         # Init monitoring parameters.
         self._param_qitems = {}
         _col_names_paramtable = ['Param name', 'Found on Parameter Server?']
@@ -128,9 +121,7 @@ class MoveitWidget(QWidget):
         self._view_nodes.setModel(self._node_datamodel)
 
         node_monitor_thread = Thread(target=self._check_nodes_alive,
-                                           args=(self.sig_node,
-                                                 self._nodes_monitored,
-                                                 self._stop_event))
+                                     args=(self.sig_node, self._nodes_monitored, self._stop_event))
 
         self.sig_node.connect(self._update_output_nodes)
         return node_monitor_thread
@@ -176,9 +167,7 @@ class MoveitWidget(QWidget):
         @rtype: Thread
         """
         topic_monitor_thread = Thread(target=self._check_topics_alive,
-                                            args=(self.sig_topic,
-                                                  self._selected_topics,
-                                                  self._stop_event))
+                                      args=(self.sig_topic, self._selected_topics, self._stop_event))
         self.sig_topic.connect(self._update_output_topics)
         return topic_monitor_thread
 
@@ -227,9 +216,7 @@ class MoveitWidget(QWidget):
         self.sig_param.connect(self._update_output_parameters)
 
         param_check_thread = Thread(target=self._check_params_alive,
-                                          args=(self.sig_param,
-                                                self._params_monitored,
-                                                self._stop_event))
+                                    args=(self.sig_param, self._params_monitored, self._stop_event))
         return param_check_thread
 
     def _update_output_nodes(self, is_node_running, node_name):
@@ -354,8 +341,7 @@ class MoveitWidget(QWidget):
 
     def restore_settings(self, plugin_settings, instance_settings):
         if instance_settings.contains(self._SPLITTER_H):
-            self._splitter.restoreState(instance_settings.value(
-                                                             self._SPLITTER_H))
+            self._splitter.restoreState(instance_settings.value(self._SPLITTER_H))
         else:
             self._splitter.setSizes([100, 100, 200])
         pass
@@ -373,6 +359,7 @@ class MoveitWidget(QWidget):
             self._node_monitor_thread = None
             self._param_check_thread = None
             self._topic_monitor_thread = None
+
         except RuntimeError as e:
             rospy.logerr(e)
             raise e

--- a/rqt_robot_monitor/src/rqt_robot_monitor/timeline_view.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/timeline_view.py
@@ -133,7 +133,7 @@ class TimelineView(QGraphicsView):
         """
         width = self.size().width()
         # determine value from mouse click
-        width_cell = width / float(len(self._timeline))
+        width_cell = width / float(max(len(self._timeline), 1))
         return int(floor(x / width_cell))
 
     def set_marker_pos(self, xpos):


### PR DESCRIPTION
**_rqt_robot_monitor/timeline_view.py:_**
It was possible to cause a division by zero when no diagnostic_aggregator was available yet and the the timeline was left uninitialized. This was fixed by wrapping the problematic call into another max(...,1) call by this the timeline will get the full with.

**_rqt_moveit/moveit_widget.py_**

1. The signal _sig_sysmsg_ was not available within _TopicWidget_ what caused a crash directly after the start. According to [plugin_container_widget.py](https://github.com/ros-visualization/rqt_common_plugins/blob/master/rqt_py_common/src/rqt_py_common/plugin_container_widget.py) this should be automatically connected. So this is just initialized as a signal accepting strings for the system messages. This should fix this [issue](https://github.com/ros-visualization/rqt_robot_plugins/issues/77)
2. The availability of topics is now checked using the ROS master API before the topics are handed over to the TopicView widget. This should fix this [issue](https://github.com/ros-visualization/rqt_robot_plugins/issues/76)
But no messages were added to the gui to indicate that these topics are missing. Maybe it is enough that they are not shown in the list.
3. Nodes are not pinged but checked by getting the list of all available nodes. This doesn't help if the node stales but reduces the spamming of the console a lot.
4. Threads now reacts to an event which is set on shutdown, so the user hasn't to wait for the next refresh cycle to finish till he gets returned to the console. This should fix this [issue](https://github.com/ros-visualization/rqt_robot_plugins/issues/56)
5. Minor changes like removing unused parameters and using members instead because they were used before anyway. And also some small updates on the doc.  
