### PR TITLE
prevent emitting NAN

### DIFF
--- a/rqt_robot_monitor/src/rqt_robot_monitor/inspector_window.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/inspector_window.py
@@ -102,12 +102,13 @@ class InspectorWindow(QWidget):
 
         rospy.logdebug('InspectorWin message_updated')
 
-        self.status = status
-        self.disp.write_status.emit(status)
+        if status:
+            self.status = status
+            self.disp.write_status.emit(status)
 
-        if self.disp.verticalScrollBar().maximum() < scroll_value:
-            scroll_value = self.disp.verticalScrollBar().maximum()
-        self.disp.verticalScrollBar().setValue(scroll_value)
+            if self.disp.verticalScrollBar().maximum() < scroll_value:
+                scroll_value = self.disp.verticalScrollBar().maximum()
+            self.disp.verticalScrollBar().setValue(scroll_value)
 
     def _take_snapshot(self):
         snap = StatusSnapshot(status=self.status)


### PR DESCRIPTION
To avoid

```
Traceback (most recent call last):
  File "/home/jihoonl/work/ros/mine/src/rqt_robot_plugins/rqt_robot_monitor/src/rqt_robot_monitor/inspector_window.py", line 107, in message_updated
    self.disp.write_status.emit(status)
TypeError: StatusSnapshot.write_status[DiagnosticStatus].emit(): argument 1 has unexpected type 'NoneType'
```