### PR TITLE
use Python 3 compatible syntax

### DIFF
--- a/rqt_nav_view/src/rqt_nav_view/nav_view.py
+++ b/rqt_nav_view/src/rqt_nav_view/nav_view.py
@@ -435,11 +435,11 @@ class NavView(QGraphicsView):
     def close(self):
         if self.map_sub:
             self.map_sub.unregister()
-        for p in self._paths.itervalues():
+        for p in self._paths.values():
             if p.sub:
                 p.sub.unregister()
 
-        for p in self._polygons.itervalues():
+        for p in self._polygons.values():
             if p.sub:
                 p.sub.unregister()
 

--- a/rqt_robot_dashboard/test/test_battery_dash_widget.py
+++ b/rqt_robot_dashboard/test/test_battery_dash_widget.py
@@ -63,8 +63,8 @@ class TestBatteryDashWidget(unittest.TestCase):
         val = '0.41'
         self._widget.update_time(val)
 
-        print 'toolTip={} name={}'.format(self._widget.toolTip(),
-                                          self._widget._name)
+        print('toolTip={} name={}'
+              .format(self._widget.toolTip(), self._widget._name))
         comp = "%s: %.2f%% remaining" % (self._WIDGET_NAME, float(val))
         tool_tip = self._widget.toolTip()
         self.assertEqual(comp, tool_tip)

--- a/rqt_robot_monitor/src/rqt_robot_monitor/inspector_window.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/inspector_window.py
@@ -38,7 +38,7 @@ import rospy
 
 from .status_snapshot import StatusSnapshot, level_to_text
 from .timeline_pane import TimelinePane
-import util_robot_monitor as util
+import rqt_robot_monitor.util_robot_monitor as util
 
 from diagnostic_msgs.msg import DiagnosticArray
 

--- a/rqt_robot_monitor/src/rqt_robot_monitor/robot_monitor.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/robot_monitor.py
@@ -46,7 +46,7 @@ from .inspector_window import InspectorWindow
 from .status_item import StatusItem
 from .timeline_pane import TimelinePane
 from .timeline import Timeline
-import util_robot_monitor as util
+import rqt_robot_monitor.util_robot_monitor as util
 
 class RobotMonitorWidget(QWidget):
     """

--- a/rqt_robot_monitor/src/rqt_robot_monitor/status_item.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/status_item.py
@@ -33,7 +33,7 @@
 # Author: Austin Hendrix
 
 from python_qt_binding.QtWidgets import QTreeWidgetItem
-import util_robot_monitor as util
+import rqt_robot_monitor.util_robot_monitor as util
 
 class _StatusItem(QTreeWidgetItem):
     """

--- a/rqt_robot_monitor/src/rqt_robot_monitor/status_snapshot.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/status_snapshot.py
@@ -39,7 +39,7 @@ from python_qt_binding.QtWidgets import QTextEdit
 from python_qt_binding.QtCore import Signal
 
 from diagnostic_msgs.msg import DiagnosticStatus
-from util_robot_monitor import level_to_text
+from rqt_robot_monitor.util_robot_monitor import level_to_text
 
 class StatusSnapshot(QTextEdit):
     """Display a single static status message. Helps facilitate copy/paste"""

--- a/rqt_robot_monitor/src/rqt_robot_monitor/timeline_view.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/timeline_view.py
@@ -40,7 +40,7 @@ from python_qt_binding.QtGui import QColor, QIcon
 from python_qt_binding.QtWidgets import QGraphicsPixmapItem, QGraphicsView, \
     QGraphicsScene
 
-import util_robot_monitor as util
+import rqt_robot_monitor.util_robot_monitor as util
 
 
 class TimelineView(QGraphicsView):

--- a/rqt_runtime_monitor/src/rqt_runtime_monitor/runtime_monitor_widget.py
+++ b/rqt_runtime_monitor/src/rqt_runtime_monitor/runtime_monitor_widget.py
@@ -32,7 +32,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import copy
-import cStringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 import os
 import rospkg
 import threading
@@ -169,7 +172,7 @@ class RuntimeMonitorWidget(QWidget):
         for message in messages:
             for status in message.status:
                 was_selected = False
-                if (self._name_to_item.has_key(status.name)):
+                if (status.name in self._name_to_item):
                     item = self._name_to_item[status.name]
                     if item.tree_node.isSelected():
                         was_selected = True
@@ -270,7 +273,7 @@ class RuntimeMonitorWidget(QWidget):
         scroll_value = self.html_browser.verticalScrollBar().value()
         status = item.status
 
-        s = cStringIO.StringIO()
+        s = StringIO()
 
         s.write("<html><body>")
         s.write("<b>Component</b>: %s<br>\n" % (status.name))
@@ -319,7 +322,7 @@ class RuntimeMonitorWidget(QWidget):
         if self._previous_ros_time + rospy.Duration(5) > rospy.Time.now():
             return
         self._previous_ros_time = rospy.Time.now()
-        for name, item in self._name_to_item.iteritems():
+        for name, item in self._name_to_item.items():
             node = item.tree_node
             if (item != None):
                 if (not item.mark):

--- a/rqt_tf_tree/src/rqt_tf_tree/tf_tree.py
+++ b/rqt_tf_tree/src/rqt_tf_tree/tf_tree.py
@@ -166,9 +166,9 @@ class RosTfTree(QObject):
         (nodes, edges) = self.dot_to_qt.dotcode_to_qt_items(self._current_dotcode,
                                                             highlight_level)
 
-        for node_item in nodes.itervalues():
+        for node_item in nodes.values():
             self._scene.addItem(node_item)
-        for edge_items in edges.itervalues():
+        for edge_items in edges.values():
             for edge_item in edge_items:
                 edge_item.add_to_scene(self._scene)
 


### PR DESCRIPTION
While this patch doesn't guarantee that Python 3 works all the way it at last uses Python 3 compatible syntax and addresses obvious problems starting `rqt` and its plugins.