### PR TITLE
[robot_dashboard] Fix error 'NoneType' object has no attribute '_paused'

### DIFF
--- a/rqt_robot_dashboard/src/rqt_robot_dashboard/console_dash_widget.py
+++ b/rqt_robot_dashboard/src/rqt_robot_dashboard/console_dash_widget.py
@@ -67,11 +67,16 @@ class ConsoleDashWidget(IconToolButton):
         self._proxymodel = MessageProxyModel()
         self._proxymodel.setSourceModel(self._datamodel)
 
+        self._console = None
+        self._rospack = rospkg.RosPack()
+        if self._console is None:
+            self._console = ConsoleWidget(self._proxymodel, self._rospack, minimal=self.minimal)
+            self._console.destroyed.connect(self._console_destroyed)
+
         self._message_queue = []
         self._mutex = QMutex()
         self._subscriber = rospy.Subscriber('/rosout_agg', Log, self._message_cb)
 
-        self._console = None
         self.context = context
         self.clicked.connect(self._show_console)
 
@@ -80,10 +85,6 @@ class ConsoleDashWidget(IconToolButton):
         self._timer.timeout.connect(self._insert_messages)
         self._timer.start(100)
 
-        self._rospack = rospkg.RosPack()
-        if self._console is None:
-            self._console = ConsoleWidget(self._proxymodel, self._rospack, minimal=self.minimal)
-            self._console.destroyed.connect(self._console_destroyed)
         self._console_shown = False
         self.setToolTip("Rosout")
 


### PR DESCRIPTION
**Issue**
Callback _message_cb is called before ConsoleWidget is instantiated, so during the initializing of the robot_dashboard plugin the following error can keep happening for awhile.

```
[ERROR] [WallTime: 1490999099.241694] [4.180000] bad callback: <bound method ConsoleDashWidget._message_cb of <rqt_robot_dashboard.console_dash_widget.ConsoleDashWidget object at
0x7f58f3b0c9d0>>
Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/topics.py", line 720, in _invoke_callback
    cb(msg)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_robot_dashboard/console_dash_widget.py", line 120, in _message_cb
    if not self._console._paused:
AttributeError: 'NoneType' object has no attribute '_paused'
```

**Fix**
Move ConsoleWidget instantiation before the plugin starts subscribing.